### PR TITLE
fix the create org url

### DIFF
--- a/GogsKit/Clients/AdminClient.cs
+++ b/GogsKit/Clients/AdminClient.cs
@@ -87,7 +87,7 @@ namespace GogsKit
 
             if (org == null) throw new ArgumentNullException(nameof(org));
 
-            var requestUrl = context.CreateRequestUri($"admin/{username}/orgs");
+            var requestUrl = context.CreateRequestUri($"admin/users/{username}/orgs");
             using (var httpClient = await context.CreateHttpClientAsync())
             using (var requestContent = new StringContent(org.ToJson(), Encoding.UTF8, mediaType: "application/json"))
             {


### PR DESCRIPTION
fix the create org url to prevent 404 errors.
see [api.go](https://github.com/gogits/gogs/blob/master/routers/api/v1/api.go) line 317 for route path implemented in gogs (it isn't really what you'd expect)